### PR TITLE
Add MachXO2 spine row handling

### DIFF
--- a/machxo2/arch.cc
+++ b/machxo2/arch.cc
@@ -602,6 +602,15 @@ std::vector<WireId> Arch::getGroupWires(GroupId group) const
     return ret;
 }
 
+bool Arch::is_spine_row(int row) const
+{
+    for (auto &si : chip_info->spine_info) {
+        if (si.row == row)
+            return true;
+    }
+    return false;
+}
+
 std::vector<PipId> Arch::getGroupPips(GroupId group) const
 {
     std::vector<PipId> ret;

--- a/machxo2/arch.h
+++ b/machxo2/arch.h
@@ -126,6 +126,11 @@ NPNR_PACKED_STRUCT(struct SuffixeSupportedPOD { RelPtr<char> suffix; });
 
 NPNR_PACKED_STRUCT(struct SpeedSupportedPOD { int32_t speed; });
 
+NPNR_PACKED_STRUCT(struct SpineInfoPOD {
+    int16_t row;
+    int16_t padding;
+});
+
 NPNR_PACKED_STRUCT(struct VariantInfoPOD {
     RelPtr<char> name;
     RelSlice<PackageSupportedPOD> packages;
@@ -144,6 +149,7 @@ NPNR_PACKED_STRUCT(struct ChipInfoPOD {
     RelSlice<PackageInfoPOD> package_info;
     RelSlice<PIOInfoPOD> pio_info;
     RelSlice<TileInfoPOD> tile_info;
+    RelSlice<SpineInfoPOD> spine_info;
     RelSlice<VariantInfoPOD> variants;
 });
 
@@ -959,6 +965,8 @@ struct Arch : BaseArch<ArchRanges>
         }
         NPNR_ASSERT_FALSE_STR("no tile with type " + type);
     }
+
+    bool is_spine_row(int row) const;
 
     // Apply LPF constraints to the context
     bool apply_lpf(std::string filename, std::istream &in);

--- a/machxo2/facade_import.py
+++ b/machxo2/facade_import.py
@@ -164,6 +164,7 @@ def get_bel_index(rg, loc, name):
 packages = {}
 pindata = []
 variants = {}
+spine_rows = []
 
 def process_devices_db(family, device):
     devicefile = path.join(database.get_db_root(), "devices.json")
@@ -210,8 +211,12 @@ def process_pio_db(rg, device):
                 #     suffix_size += 1
                 # dqs |= int(tdqs[-suffix_size:])
             bel_idx = get_bel_index(rg, loc, pio)
-            if bel_idx is not None:
-                pindata.append((loc, bel_idx, bank, pinfunc, dqs))
+        if bel_idx is not None:
+            pindata.append((loc, bel_idx, bank, pinfunc, dqs))
+
+def process_spine_rows(chip):
+    for r in chip.global_data.get_spine_rows():
+        spine_rows.append(r)
 
 def write_database(dev_name, chip, rg, endianness):
     def write_loc(loc, sym_name):
@@ -371,6 +376,11 @@ def write_database(dev_name, chip, rg, endianness):
         bba.u16(bank, "bank")
         bba.u16(dqs, "dqsgroup")
 
+    bba.l("spine_info", "SpineInfoPOD")
+    for r in spine_rows:
+        bba.u16(r, "row")
+        bba.u16(0, "padding")
+
     bba.l("tiletype_names", "RelPtr<char>")
     for tt, idx in sorted(tiletype_names.items(), key=lambda x: x[1]):
         bba.s(tt, "name")
@@ -406,6 +416,7 @@ def write_database(dev_name, chip, rg, endianness):
     bba.r_slice("tiletype_names", len(tiletype_names), "tiletype_names")
     bba.r_slice("package_data", len(packages), "package_info")
     bba.r_slice("pio_info", len(pindata), "pio_info")
+    bba.r_slice("spine_info", len(spine_rows), "spine_info")
     bba.r_slice("tiles_info", (max_col + 1) * (max_row + 1), "tile_info")
     bba.r_slice("variant_data", len(variants), "variant_info")
 
@@ -487,6 +498,7 @@ def main():
     max_row = chip.get_max_row()
     max_col = chip.get_max_col()
     process_pio_db(rg, args.device)
+    process_spine_rows(chip)
     process_devices_db(chip.info.family, chip.info.name)
     bba = write_database(args.device, chip, rg, "le")
 


### PR DESCRIPTION
## Summary
- define `SpineInfoPOD` and expose spine slice vector in chipdb
- add `is_spine_row` utility to `arch.cc`
- load spine information in `facade_import.py`

## Testing
- `git status --short`